### PR TITLE
Device sort and search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ typings/
 dist/
 .DS_Store
 .cache
+react-front/.vscode/

--- a/react-front/index.html
+++ b/react-front/index.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" type="text/css" href="public/styles/reset.css" />
     <link rel="stylesheet" type="text/css" href="public/styles/main.css" />
     <link href="https://fonts.googleapis.com/css?family=Karla:400,700|Montserrat&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css" />
     <title>My App</title>
   </head>
 

--- a/react-front/public/components/App.js
+++ b/react-front/public/components/App.js
@@ -28,12 +28,17 @@ class App extends React.Component {
     }
   };
 
-  getDevicesData = () => {
+  getDevicesData = (sortField = "id", filterField, filterValue) => {
     // check that button click works
     const credentials =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw";
+    let filterParams = "";
     console.log("you clicked the button");
-    fetch("https://tug-lab.cnaas.sunet.se:8443/api/v1.0/devices", {
+    if (filterField != null && filterValue != null) {
+      filterParams = "&filter["+filterField+"][contains]="+filterValue;
+    }
+
+    fetch("https://tug-lab.cnaas.sunet.se:8443/api/v1.0/devices?sort="+sortField+filterParams, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${credentials}`

--- a/react-front/public/components/DeviceList.js
+++ b/react-front/public/components/DeviceList.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Dropdown } from 'semantic-ui-react';
+import PropTypes from 'prop-types'
+import DeviceSearchForm from "./DeviceSearchForm";
 
 class DeviceList extends React.Component {
   state = {
@@ -36,11 +37,11 @@ class DeviceList extends React.Component {
     newState['hostname_sort'] = '';
     newState['device_type_sort'] = '';
     newState['synchronized_sort'] = '';
-    if (oldValue == '' || oldValue == '↓') {
-      newState[header+'_sort'] = "↑";
-      sortField = header;
-    } else if (oldValue == '↑') {
+    if (oldValue == '' || oldValue == '↑') {
       newState[header+'_sort'] = "↓";
+      sortField = header;
+    } else if (oldValue == '↓') {
+      newState[header+'_sort'] = "↑";
       sortField = "-"+header;
     }
     this.setState(newState);
@@ -79,14 +80,12 @@ class DeviceList extends React.Component {
 
     return (
       <div id="component">
-        <div id="request">
+        <div id="search">
           {/* <h2> Make a request </h2> */}
-          <button onClick={()=>this.getDevicesData()}> API request </button>
-          <button onClick={()=>this.getDevicesData({ filterField: "hostname", filterValue: "arista" })}> Filter </button>
-          <button onClick={()=>this.getDevicesData({ filterField: null, filterValue: null })}> Clear filter </button>
+          <DeviceSearchForm searchAction={this.getDevicesData} />
         </div>
-        <div id="response">
-          <h2> Get the response</h2>
+        <div id="device_list">
+          <h2>Device list</h2>
           <div id="data">
             {/* the static part of the table that will hold the response data */}
             <table>
@@ -106,6 +105,11 @@ class DeviceList extends React.Component {
       </div>
     );
   }
+}
+
+DeviceList.propTypes = {
+  getDevicesData: PropTypes.func.isRequired,
+  devicesData: PropTypes.array.isRequired
 }
 
 export default DeviceList;

--- a/react-front/public/components/DeviceList.js
+++ b/react-front/public/components/DeviceList.js
@@ -1,6 +1,30 @@
 import React from "react";
 
 class DeviceList extends React.Component {
+  state = {
+    sortField: "id",
+    filterField: null,
+    filterValue: null
+  };
+
+  getDevicesData = (options) => {
+    if (options === undefined) options = {};
+    let newState = this.state;
+    if (options.sortField !== undefined) {
+      newState['sortField'] = options.sortField;
+    }
+    if (options.filterField !== undefined && options.filterValue !== undefined) {
+      newState['filterField'] = options.filterField;
+      newState['filterValue'] = options.filterValue;
+    }
+    this.setState(newState);
+    return this.props.getDevicesData(
+      newState['sortField'],
+      newState['filterField'],
+      newState['filterValue']
+    );
+  };
+
   render() {
     console.log("these are props (in DeviceList)", this.props);
     console.log("this is device data (in DeviceList)", this.props.devicesData);
@@ -31,7 +55,9 @@ class DeviceList extends React.Component {
       <div id="component">
         <div id="request">
           {/* <h2> Make a request </h2> */}
-          <button onClick={this.props.getDevicesData}> API request </button>
+          <button onClick={()=>this.getDevicesData()}> API request </button>
+          <button onClick={()=>this.getDevicesData({ filterField: "hostname", filterValue: "arista" })}> Filter </button>
+          <button onClick={()=>this.getDevicesData({ filterField: null, filterValue: null })}> Clear filter </button>
         </div>
         <div id="response">
           <h2> Get the response</h2>
@@ -40,9 +66,9 @@ class DeviceList extends React.Component {
             <table>
               <thead>
                 <tr>
-                  <th>Hostname</th>
-                  <th>Device type</th>
-                  <th>Sync. status</th>
+                  <th onClick={()=>this.getDevicesData({ sortField: "hostname" })}>Hostname</th>
+                  <th onClick={()=>this.getDevicesData({ sortField: "device_type" })}>Device type</th>
+                  <th onClick={()=>this.getDevicesData({ sortField: "synchronized" })}>Sync. status</th>
                   <th>id</th>
                 </tr>
               </thead>

--- a/react-front/public/components/DeviceList.js
+++ b/react-front/public/components/DeviceList.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from 'prop-types'
 import DeviceSearchForm from "./DeviceSearchForm";
 
 class DeviceList extends React.Component {
@@ -148,11 +147,6 @@ class DeviceList extends React.Component {
       </section>
     );
   }
-}
-
-DeviceList.propTypes = {
-  getDevicesData: PropTypes.func.isRequired,
-  devicesData: PropTypes.array.isRequired
 }
 
 export default DeviceList;

--- a/react-front/public/components/DeviceList.js
+++ b/react-front/public/components/DeviceList.js
@@ -1,10 +1,14 @@
 import React from "react";
+import { Dropdown } from 'semantic-ui-react';
 
 class DeviceList extends React.Component {
   state = {
     sortField: "id",
     filterField: null,
-    filterValue: null
+    filterValue: null,
+    hostname_sort: "",
+    device_type_sort: "",
+    synchronized_sort: "",
   };
 
   getDevicesData = (options) => {
@@ -23,6 +27,24 @@ class DeviceList extends React.Component {
       newState['filterField'],
       newState['filterValue']
     );
+  };
+
+  sortHeader = (header) => {
+    let newState = this.state;
+    let sortField = "id";
+    const oldValue = this.state[header+'_sort'];
+    newState['hostname_sort'] = '';
+    newState['device_type_sort'] = '';
+    newState['synchronized_sort'] = '';
+    if (oldValue == '' || oldValue == '↓') {
+      newState[header+'_sort'] = "↑";
+      sortField = header;
+    } else if (oldValue == '↑') {
+      newState[header+'_sort'] = "↓";
+      sortField = "-"+header;
+    }
+    this.setState(newState);
+    this.getDevicesData({ sortField: sortField });
   };
 
   render() {
@@ -66,9 +88,9 @@ class DeviceList extends React.Component {
             <table>
               <thead>
                 <tr>
-                  <th onClick={()=>this.getDevicesData({ sortField: "hostname" })}>Hostname</th>
-                  <th onClick={()=>this.getDevicesData({ sortField: "device_type" })}>Device type</th>
-                  <th onClick={()=>this.getDevicesData({ sortField: "synchronized" })}>Sync. status</th>
+                  <th onClick={()=>this.sortHeader("hostname")}>Hostname <div className="hostname_sort">{this.state.hostname_sort}</div></th>
+                  <th onClick={()=>this.sortHeader("device_type")}>Device type<div className="device_type_sort">{this.state.device_type_sort}</div></th>
+                  <th onClick={()=>this.sortHeader("synchronized")}>Sync. status<div className="sync_status_sort">{this.state.synchronized_sort}</div></th>
                   <th>id</th>
                 </tr>
               </thead>

--- a/react-front/public/components/DeviceList.js
+++ b/react-front/public/components/DeviceList.js
@@ -47,6 +47,10 @@ class DeviceList extends React.Component {
     this.getDevicesData({ sortField: sortField });
   };
 
+  componentDidMount() {
+    this.getDevicesData();
+  }
+
   render() {
     console.log("these are props (in DeviceList)", this.props);
     console.log("this is device data (in DeviceList)", this.props.devicesData);

--- a/react-front/public/components/DeviceSearchForm.js
+++ b/react-front/public/components/DeviceSearchForm.js
@@ -3,14 +3,10 @@ import PropTypes from 'prop-types'
 import { Button, Select, Input, Icon } from 'semantic-ui-react'
 
 class DeviceSearchForm extends React.Component {
-
-  constructor(props) {
-    super(props);
-    this.state = {
+  state = {
       searchText: "",
       searchField: "hostname"
-    };
-  }
+  };
 
   updateSearchText(e) {
     const val = e.target.value;

--- a/react-front/public/components/DeviceSearchForm.js
+++ b/react-front/public/components/DeviceSearchForm.js
@@ -1,0 +1,75 @@
+import React from "react";
+import PropTypes from 'prop-types'
+import { Button, Select, Input, Icon } from 'semantic-ui-react'
+
+class DeviceSearchForm extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      searchText: "",
+      searchField: "hostname"
+    };
+  }
+
+  updateSearchText(e) {
+    const val = e.target.value;
+    this.setState({
+      searchText: val
+    });
+  }
+
+  updateSearchField(e, option) {
+    const val = option.value;
+    this.setState({
+      searchField: val
+    });
+  }
+
+  clearSearch(e) {
+    this.setState({
+      searchText: ""
+    });
+    this.props.searchAction({ filterField: null, filterValue: null });
+  }
+
+  submitSearch(e) {
+    e.preventDefault();
+    console.log("search submitted: "+this.state.searchText+" "+this.state.searchField);
+    this.props.searchAction({ filterField: this.state.searchField, filterValue: this.state.searchText});
+  }
+
+  render() {
+    const searchOptions = [
+      { 'key': 'hostname', 'value': 'hostname', 'text': 'Hostname' },
+      { 'key': 'id', 'value': 'id', 'text': 'ID' },
+      { 'key': 'management_ip', 'value': 'management_ip', 'text': 'Management IP' },
+      { 'key': 'serial', 'value': 'serial', 'text': 'Serial number' },
+      { 'key': 'ztp_mac', 'value': 'ztp_mac', 'text': 'MAC' },
+      { 'key': 'platform', 'value': 'platform', 'text': 'Platform' },
+      { 'key': 'vendor', 'value': 'vendor', 'text': 'Vendor' },
+      { 'key': 'model', 'value': 'model', 'text': 'Hardware model' },
+      { 'key': 'os_version', 'value': 'os_version', 'text': 'OS version' },
+      { 'key': 'state', 'value': 'state', 'text': 'State' },
+    ]
+
+    return (
+      <form onSubmit={this.submitSearch.bind(this)}>
+        <Input type='text' placeholder='Search...' action
+          onChange={this.updateSearchText.bind(this)}
+          icon={<Icon name='delete' link onClick={this.clearSearch.bind(this)}/>}
+          value={this.state.searchText}
+        />
+        <Select compact options={searchOptions} defaultValue='hostname' onChange={this.updateSearchField.bind(this)} />
+        <Button type='submit'>Search</Button>
+      </form>
+    );
+
+  }
+}
+
+DeviceSearchForm.propTypes = {
+  searchAction: PropTypes.func.isRequired,
+}
+
+export default DeviceSearchForm;


### PR DESCRIPTION
1. Add ability to sort device list by clicking on the header (and reverse sort by clicking again)
2. Add ability to search different fields (works together with the sorting), delete/cross icon clears the search

This adds dependencies on Semantic UI for the components used in the search form