### PR TITLE
Adds options to retry dry run on error 

### DIFF
--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -21,17 +21,19 @@ class ConfigChangeStep2 extends React.Component {
       },
       () => {
         this.deviceSyncTo();
-      }
+      },
+      this.setState(prevState => ({
+        dataToSend: !prevState.dataToSend
+      }))
     );
   };
 
   deviceSyncTo = () => {
-    // let dataToSend = { dry_run: true, all: true };
+    const credentials = this.state.token;
+    let url = "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/device_syncto";
     let dataToSend = this.state.dataToSend;
     console.log("this is dataToSend", dataToSend);
-    const credentials = this.state.token;
     console.log("you clicked the start sync info button");
-    let url = "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/device_syncto";
     postData(url, credentials, dataToSend).then(data => {
       console.log("this should be data", data);
       {
@@ -120,7 +122,7 @@ class ConfigChangeStep2 extends React.Component {
     }
     // allow a force retry of dry run if it errored
     // jobStatus === "EXCEPTION"
-    if (true) {
+    if (jobStatus === "FINISHED") {
       console.log("jobStatus errored");
       error = [
         <div>

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -126,11 +126,11 @@ class ConfigChangeStep2 extends React.Component {
       console.log("jobStatus errored");
       error = [
         <div>
-          <p>something went wrong</p>
-          <button key="0" onClick={this.deviceSyncTo}>
+          <p key="0">something went wrong</p>
+          <button key="1" onClick={this.deviceSyncTo}>
             Retry
           </button>
-          <button key="1" onClick={this.deviceSyncToWithForce}>
+          <button key="2" onClick={this.deviceSyncToWithForce}>
             Force retry
           </button>
         </div>
@@ -139,18 +139,18 @@ class ConfigChangeStep2 extends React.Component {
 
     return (
       <div className="workflow-container">
-        <div className="workflow-container__header">
+        <div key="0" className="workflow-container__header">
           <h2>Dry run (2/4)</h2>
           <a href="#">
             <button className="workflow-container__button--hide">Close</button>
           </a>
         </div>
-        <div className="workflow-collapsable">
+        <div key="1" className="workflow-collapsable">
           <p>
             Step 2 of 4: Sending generated configuration to devices to calculate
             diff and check sanity
           </p>
-          <div className="workflow-collapsable__button-result">
+          <div key="2" className="workflow-collapsable__button-result">
             <button key="0" onClick={this.deviceSyncTo}>
               Start sync
             </button>
@@ -158,19 +158,19 @@ class ConfigChangeStep2 extends React.Component {
             <p>{syncStatus}</p>
             <p>{syncJobId}</p>
           </div>
-          <div>
+          <div key="3">
             <ConfigChangeProgressBar
               finishedDevices={finishedDevices}
               totalDevices={totalDevices}
             />
           </div>
-          <div>
+          <div key="4">
             <p>status: {syncStatus}</p>
             <p>start time: {jobStartTime}</p>
             <p>finish time: {jobFinishTime}</p>
           </div>
 
-          <div>{error}</div>
+          <div key="5">{error}</div>
         </div>
       </div>
     );

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -68,6 +68,7 @@ class ConfigChangeStep2 extends React.Component {
   }
 
   render() {
+    let error = "";
     // extract sync data
     let syncData = this.state.syncData;
     let syncMessage = syncData.data;
@@ -105,20 +106,30 @@ class ConfigChangeStep2 extends React.Component {
     }
     // allow a force retry of dry run if it errored
     // jobStatus === "EXCEPTION"
-    if (true) {
+    if (jobStatus === "FINISHED") {
       console.log("jobStatus errored");
-      
+      error = [
+        <div>
+          <p key="0">something went wrong</p>
+          <button key="1" onClick={this.syncStatus}>
+            Retry
+          </button>
+          <button key="2" onClick={this.syncStatus({force: true})}>
+            Force retry
+          </button>
+        </div>
+      ];
     }
 
     return (
       <div className="workflow-container">
-        <div className="workflow-container__header">
+        <div key="0" className="workflow-container__header">
           <h2>Dry run (2/4)</h2>
           <a href="#">
             <button className="workflow-container__button--hide">Close</button>
           </a>
         </div>
-        <div className="workflow-collapsable">
+        <div key="1" className="workflow-collapsable">
           <p>
             Step 2 of 4: Sending generated configuration to devices to calculate
             diff and check sanity
@@ -131,17 +142,18 @@ class ConfigChangeStep2 extends React.Component {
             <p>{syncStatus}</p>
             <p>{syncJobId}</p>
           </div>
-          <div>
+          <div key="2">
             <ConfigChangeProgressBar
               finishedDevices={finishedDevices}
               totalDevices={totalDevices}
             />
           </div>
-          <div>
+          <div key="3">
             <p>status: {syncStatus}</p>
             <p>start time: {jobStartTime}</p>
             <p>finish time: {jobFinishTime}</p>
           </div>
+          <div key="4">{error}</div>
         </div>
       </div>
     );

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -9,15 +9,29 @@ class ConfigChangeStep2 extends React.Component {
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw",
     syncData: [],
     jobsData: [],
-    repeatingData: [] // setInterval ID saved in state to be accessible to all class methods
+    repeatingData: [], // setInterval ID saved in state to be accessible to all class methods
+    dataToSend: { dry_run: true, all: true }
     // errorMessage: ""
   };
 
+  deviceSyncToWithForce = () => {
+    this.setState(
+      {
+        dataToSend: { dry_run: true, all: true, force: true }
+      },
+      () => {
+        this.deviceSyncTo();
+      }
+    );
+  };
+
   deviceSyncTo = () => {
+    // let dataToSend = { dry_run: true, all: true };
+    let dataToSend = this.state.dataToSend;
+    console.log("this is dataToSend", dataToSend);
     const credentials = this.state.token;
     console.log("you clicked the start sync info button");
     let url = "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/device_syncto";
-    let dataToSend = { dry_run: true, all: true };
     postData(url, credentials, dataToSend).then(data => {
       console.log("this should be data", data);
       {
@@ -106,15 +120,15 @@ class ConfigChangeStep2 extends React.Component {
     }
     // allow a force retry of dry run if it errored
     // jobStatus === "EXCEPTION"
-    if (jobStatus === "FINISHED") {
+    if (true) {
       console.log("jobStatus errored");
       error = [
         <div>
-          <p key="0">something went wrong</p>
-          <button key="1" onClick={this.syncStatus}>
+          <p>something went wrong</p>
+          <button key="0" onClick={this.deviceSyncTo}>
             Retry
           </button>
-          <button key="2" onClick={this.syncStatus({force: true})}>
+          <button key="1" onClick={this.deviceSyncToWithForce}>
             Force retry
           </button>
         </div>
@@ -123,13 +137,13 @@ class ConfigChangeStep2 extends React.Component {
 
     return (
       <div className="workflow-container">
-        <div key="0" className="workflow-container__header">
+        <div className="workflow-container__header">
           <h2>Dry run (2/4)</h2>
           <a href="#">
             <button className="workflow-container__button--hide">Close</button>
           </a>
         </div>
-        <div key="1" className="workflow-collapsable">
+        <div className="workflow-collapsable">
           <p>
             Step 2 of 4: Sending generated configuration to devices to calculate
             diff and check sanity
@@ -142,18 +156,19 @@ class ConfigChangeStep2 extends React.Component {
             <p>{syncStatus}</p>
             <p>{syncJobId}</p>
           </div>
-          <div key="2">
+          <div>
             <ConfigChangeProgressBar
               finishedDevices={finishedDevices}
               totalDevices={totalDevices}
             />
           </div>
-          <div key="3">
+          <div>
             <p>status: {syncStatus}</p>
             <p>start time: {jobStartTime}</p>
             <p>finish time: {jobFinishTime}</p>
           </div>
-          <div key="4">{error}</div>
+
+          <div>{error}</div>
         </div>
       </div>
     );

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -95,14 +95,20 @@ class ConfigChangeStep2 extends React.Component {
       // let finishedDevices = job.finished_devices.length;
       // let totalDevices = job.result._totals.selected_devices;
       // let exceptionText = job.exception;
-
-      // stop the setInterval when job status is finished
-      if (jobStatus === "FINISHED" || jobStatus === "EXCEPTION" ) {
-        console.log("jobStatus is finished or errored");
-        clearInterval(this.state.repeatingData);
-      }
       return jobStatus, jobStartTime, jobFinishTime, finishedDevices;
     });
+
+    // stop the setInterval when job status is finished
+    if (jobStatus === "FINISHED" || jobStatus === "EXCEPTION") {
+      console.log("jobStatus is finished or errored");
+      clearInterval(this.state.repeatingData);
+    }
+    // allow a force retry of dry run if it errored
+    // jobStatus === "EXCEPTION"
+    if (true) {
+      console.log("jobStatus errored");
+      
+    }
 
     return (
       <div className="workflow-container">


### PR DESCRIPTION
**Background**: Add in options for when dry run fails (status : "EXCEPTION") in step 2 of ConfigChange. Allow users to "Retry" or "Force retry" the dry run.

> :warning: **Warning for mock data:** Because I don't know a way to get the API to return job status "EXCEPTION", for now the error message and retry buttons appear when job status is "FINISHED". This makes all info say success, but also renders error related UI.

<img width="390" alt="Screenshot 2019-12-02 at 12 46 05" src="https://user-images.githubusercontent.com/30963614/69958370-f30d2980-1504-11ea-9f34-afd5ad0a4dde.png">


**Summary**: 
- I have added a "something went wrong" line just to see that the buttons render when I expect
- I have added `dataToSend` to the state (initially `state.dataToSend: { dry_run: true, all: true }` )
- I have added a "Retry" button that just repeats the `deviceSyncTo()`, initial API call with the initial `state.dataToSend` 
- I have also added a "Force retry" button which triggers `deviceSyncToWithForce()`, a function that: 
     -  changes the `this.state.dataToSend` to `state.dataToSend: { dry_run: true, all: true, force: true }`
     -  triggers `deviceSyncTo()` to make the initial API call with the updated `state.dataToSend`
     -  resets `this.state.dataToSend` to its previous state

