### PR TITLE
Adds DeviceFailList: displays the names of devices that failed dry run sync

### DIFF
--- a/react-front/public/components/ConfigChange/ConfigChange.js
+++ b/react-front/public/components/ConfigChange/ConfigChange.js
@@ -12,7 +12,9 @@ class ConfigChange extends React.Component {
     token:
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw",
     dryRunSyncData: [],
-    dryRunProgressData: []
+    dryRunSyncJobid: null,
+    dryRunProgressData: [],
+    dryRunResultData: []
     // errorMessage: ""
   };
 
@@ -73,6 +75,7 @@ class ConfigChange extends React.Component {
   render() {
     let dryRunProgressData = this.state.dryRunProgressData;
     let dryRunJobStatus = "";
+    let dryRunResults = "";
     dryRunProgressData.map((job, i) => {
       dryRunJobStatus = job.status;
     });

--- a/react-front/public/components/ConfigChange/ConfigChange.js
+++ b/react-front/public/components/ConfigChange/ConfigChange.js
@@ -12,7 +12,7 @@ class ConfigChange extends React.Component {
     token:
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw",
     dryRunSyncData: [],
-    dryRunProgressData: [],
+    dryRunProgressData: []
     // errorMessage: ""
   };
 
@@ -62,24 +62,42 @@ class ConfigChange extends React.Component {
       getData(url, credentials).then(data => {
         console.log("this should be data.data.jobs", data.data.jobs);
         {
-          this.setState(
-            {
-              dryRunProgressData: data.data.jobs
-            }
-          );
+          this.setState({
+            dryRunProgressData: data.data.jobs
+          });
         }
       });
     }, 500);
   };
 
   render() {
+    let dryRunProgressData = this.state.dryRunProgressData;
+    let dryRunJobStatus = "";
+    dryRunProgressData.map((job, i) => {
+      dryRunJobStatus = job.status;
+    });
+
+    if (dryRunJobStatus === "FINISHED" || dryRunJobStatus === "EXCEPTION") {
+      clearInterval(this.repeatingJobData);
+      if (dryRunJobStatus === "FINISHED") {
+        dryRunProgressData.map((job, i) => {
+          dryRunResults = job.result.devices;
+        });
+      }
+    }
+
     // console.log("hello! this is the workflow component");
     // console.log("these are props (in Workflow)", this.props);
     return (
       <section>
         <h1>Commit changes workflow</h1>
         <ConfigChangeStep1 />
-        <ConfigChangeStep2 />
+        <ConfigChangeStep2
+          dryRunSyncStart={this.dryRunSyncStart}
+          dryRunProgressData={dryRunProgressData}
+          dryRunJobStatus={dryRunJobStatus}
+          devices={dryRunResults}
+        />
         <ConfigChangeStep3 />
         <ConfigChangeStep4 />
       </section>

--- a/react-front/public/components/ConfigChange/ConfigChange.js
+++ b/react-front/public/components/ConfigChange/ConfigChange.js
@@ -47,12 +47,12 @@ class ConfigChange extends React.Component {
   pollJobStatus = () => {
     // job id leading to finish / some devices failing / no diff
     // use jobId from API in url
-    // let jobId = this.state.dryRunSyncData.job_id;
+    let jobId = this.state.dryRunSyncData.job_id;
     // let jobId = "16";
     // job id leading to finish
     // let jobId = "5ddbe1548b2d390c963b97d8";
     // job id leading to finish / diff
-    let jobId = "5";
+    // let jobId = "5";
     // let jobId = "5de8d5608b2d394fe74709a0";
     // job id leading to exception
     // let jobId = "12";

--- a/react-front/public/components/ConfigChange/ConfigChange.js
+++ b/react-front/public/components/ConfigChange/ConfigChange.js
@@ -4,12 +4,72 @@ import ConfigChangeStep2 from "./ConfigChangeStep2";
 import ConfigChangeStep3 from "./ConfigChangeStep3";
 import ConfigChangeStep4 from "./ConfigChangeStep4";
 
+import { postData } from "../../utils/sendData";
+import getData from "../../utils/getData";
+
 class ConfigChange extends React.Component {
   state = {
-    // token: "",
-    // commitInfo: [],
-    // latestCommitInfo: []
+    token:
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw",
+    dryRunSyncData: [],
+    dryRunProgressData: [],
     // errorMessage: ""
+  };
+
+  dryRunSyncStart = e => {
+    const credentials = this.state.token;
+    let url = "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/device_syncto";
+    let dataToSend = { dry_run: true, all: true };
+    if (e.target.id === "force-button") {
+      dataToSend = { dry_run: true, all: true, force: true };
+    }
+    // console.log("this is whats used in func", dataToSend);
+    postData(url, credentials, dataToSend).then(data => {
+      console.log("this should be data", data);
+      {
+        this.setState(
+          {
+            dryRunSyncData: data
+          },
+          () => {
+            this.pollJobStatus();
+          },
+          () => {
+            console.log("this is new state", this.state.dryRunSyncData);
+          }
+        );
+      }
+    });
+  };
+
+  pollJobStatus = () => {
+    // job id leading to finish / some devices failing / no diff
+    // use jobId from API in url
+    // let jobId = this.state.dryRunSyncData.job_id;
+    // let jobId = "16";
+    // job id leading to finish
+    // let jobId = "5ddbe1548b2d390c963b97d8";
+    // job id leading to finish / diff
+    let jobId = "5";
+    // let jobId = "5de8d5608b2d394fe74709a0";
+    // job id leading to exception
+    // let jobId = "12";
+    // let jobId = "5de8d5608b2d394fe74709b0"
+    const credentials = this.state.token;
+    let url = `https://tug-lab.cnaas.sunet.se:8443/api/v1.0/job/${jobId}`;
+    this.repeatingJobData = setInterval(() => {
+      // console.log("start interval on:", jobId);
+      getData(url, credentials).then(data => {
+        console.log("this should be data.data.jobs", data.data.jobs);
+        {
+          this.setState(
+            {
+              dryRunProgressData: data.data.jobs
+            }
+          );
+        }
+      });
+    }, 500);
   };
 
   render() {

--- a/react-front/public/components/ConfigChange/ConfigChange.js
+++ b/react-front/public/components/ConfigChange/ConfigChange.js
@@ -76,8 +76,10 @@ class ConfigChange extends React.Component {
     let dryRunProgressData = this.state.dryRunProgressData;
     let dryRunJobStatus = "";
     let dryRunResults = "";
+    let dryRunChangeScore = "";
     dryRunProgressData.map((job, i) => {
       dryRunJobStatus = job.status;
+      dryRunChangeScore = job.change_score;
     });
 
     if (dryRunJobStatus === "FINISHED" || dryRunJobStatus === "EXCEPTION") {

--- a/react-front/public/components/ConfigChange/ConfigChangeProgressBar.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeProgressBar.js
@@ -7,14 +7,9 @@ class ConfigChangeProgressBar extends React.Component {
     return (
       <div>
         <div id="progressbar">
-          <progress
-            min="0"
-            max="100"
-            value={this.props.finishedDevices}
-          ></progress>
+          <progress min="0" max="100" value={this.props.value}></progress>
           <label>
-            {this.props.finishedDevices}/{this.props.totalDevices} devices
-            finished
+            {this.props.value}/{this.props.total} devices finished
           </label>
         </div>
       </div>

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ProgressBar from "./ProgressBar";
+import DeviceFailList from "./DeviceFailList";
 import getData from "../../utils/getData";
 import { postData } from "../../utils/sendData";
 
@@ -61,7 +62,7 @@ class ConfigChangeStep2 extends React.Component {
     let failingDevices = "";
     if (dryRunJobStatus === "FINISHED") {
       finishedDevices = 100;
-      // failingDevices = [<DeviceFailList devices={this.props.devices} />];
+      failingDevices = [<DeviceFailList devices={this.props.devices} />];
     }
 
     return (
@@ -86,10 +87,7 @@ class ConfigChangeStep2 extends React.Component {
               </button>
             </div>
             <div key="1">
-              <ProgressBar
-                value={finishedDevices}
-                total={totalDevices}
-              />
+              <ProgressBar value={finishedDevices} total={totalDevices} />
               <p>status: {dryRunJobStatus}</p>
               <p className="error">{exceptionMessage}</p>
               <p>start time: {jobStartTime}</p>

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -65,37 +65,39 @@ class ConfigChangeStep2 extends React.Component {
     }
 
     return (
-      <div className="workflow-container">
-        <div className="workflow-container__header">
-          <h2>Dry run (2/4)</h2>
-          <a href="#">
-            <button className="workflow-container__button--hide">Close</button>
-          </a>
-        </div>
-        <div className="workflow-collapsable">
-          <p>
-            Step 2 of 4: Sending generated configuration to devices to calculate
-            diff and check sanity
-          </p>
-          <div className="workflow-collapsable__button-result">
-            <button key="0" onClick={this.deviceSyncTo}>
-              Start sync
-            </button>
-            <p>{syncMessage}</p>
-            <p>{syncStatus}</p>
-            <p>{syncJobId}</p>
+      <div>
+        <div className="workflow-container">
+          <div className="workflow-container__header">
+            <h2>Dry run (2/4)</h2>
+            <a href="#">
+              <button className="workflow-container__button--hide">
+                Close
+              </button>
+            </a>
           </div>
-          <div>
-            <ConfigChangeProgressBar
-              finishedDevices={finishedDevices}
-              totalDevices={totalDevices}
-            />
+          <div key="1" className="workflow-collapsable">
+            <p>
+              Step 2 of 4: Sending generated configuration to devices to
+              calculate diff and check sanity
+            </p>
+            <div key="0" className="inner-content">
+              <button key="0" onClick={e => this.props.dryRunSyncStart(e)}>
+                Start config dry run
+              </button>
+            </div>
+            <div key="1">
+              <ConfigChangeProgressBar
+                value={finishedDevices}
+                total={totalDevices}
+              />
+              <p>status: {dryRunJobStatus}</p>
+              <p className="error">{exceptionMessage}</p>
+              <p>start time: {jobStartTime}</p>
+              <p>finish time: {jobFinishTime}</p>
+            </div>
           </div>
-          <div>
-            <p>status: {syncStatus}</p>
-            <p>start time: {jobStartTime}</p>
-            <p>finish time: {jobFinishTime}</p>
-          </div>
+          {failingDevices}
+          {retryButtons}
         </div>
       </div>
     );

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ConfigChangeProgressBar from "./ConfigChangeProgressBar";
+import ProgressBar from "./ProgressBar";
 import getData from "../../utils/getData";
 import { postData } from "../../utils/sendData";
 
@@ -86,7 +86,7 @@ class ConfigChangeStep2 extends React.Component {
               </button>
             </div>
             <div key="1">
-              <ConfigChangeProgressBar
+              <ProgressBar
                 value={finishedDevices}
                 total={totalDevices}
               />

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -6,61 +6,7 @@ import { postData } from "../../utils/sendData";
 class ConfigChangeStep2 extends React.Component {
   state = {
     token:
-      "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw",
-    syncData: [],
-    jobsData: [],
-    repeatingData: [] // setInterval ID saved in state to be accessible to all class methods
-    // errorMessage: ""
-  };
-
-  deviceSyncTo = () => {
-    const credentials = this.state.token;
-    console.log("you clicked the start sync info button");
-    let url = "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/device_syncto";
-    let dataToSend = { dry_run: true, all: true };
-    postData(url, credentials, dataToSend).then(data => {
-      console.log("this should be data", data);
-      {
-        this.setState(
-          {
-            syncData: data
-          },
-          () => {
-            this.syncStatus();
-          },
-          () => {
-            console.log("this is new state", this.state.syncData);
-          }
-        );
-      }
-    });
-  };
-
-  syncStatus = () => {
-    // use jobId from API in url
-    // let jobId = this.state.syncData.job_id;
-    // mock jobId that returns relevant data
-    let jobId = "5ddbe1548b2d390c963b97d8";
-    const credentials = this.state.token;
-    console.log("this API call is automatic");
-    let url = `https://tug-lab.cnaas.sunet.se:8443/api/v1.0/job/${jobId}`;
-
-    let repeatingData = setInterval(() => {
-      getData(url, credentials).then(data => {
-        console.log("this should be data.data.jobs", data.data.jobs);
-        {
-          this.setState(
-            {
-              jobsData: data.data.jobs,
-              repeatingData: repeatingData
-            },
-            () => {
-              console.log("this is jobs data", this.state.jobsData);
-            }
-          );
-        }
-      });
-    }, 500);
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw"
   };
 
   randomIntFromInterval(min, max) {
@@ -97,7 +43,7 @@ class ConfigChangeStep2 extends React.Component {
       // let exceptionText = job.exception;
 
       // stop the setInterval when job status is finished
-      if (jobStatus === "FINISHED" || jobStatus === "EXCEPTION" ) {
+      if (jobStatus === "FINISHED" || jobStatus === "EXCEPTION") {
         console.log("jobStatus is finished or errored");
         clearInterval(this.state.repeatingData);
       }

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -61,7 +61,7 @@ class ConfigChangeStep2 extends React.Component {
     let failingDevices = "";
     if (dryRunJobStatus === "FINISHED") {
       finishedDevices = 100;
-      failingDevices = [<DeviceFailList devices={this.props.devices} />];
+      // failingDevices = [<DeviceFailList devices={this.props.devices} />];
     }
 
     return (

--- a/react-front/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/react-front/public/components/ConfigChange/ConfigChangeStep2.js
@@ -14,41 +14,55 @@ class ConfigChangeStep2 extends React.Component {
   }
 
   render() {
-    // extract sync data
-    let syncData = this.state.syncData;
-    let syncMessage = syncData.data;
-    let syncStatus = syncData.status;
-    let syncJobId = syncData.job_id;
+    console.log("this is props in configchange step 2", this.props);
+    let dryRunProgressData = this.props.dryRunProgressData;
+    let dryRunJobStatus = this.props.dryRunJobStatus;
 
-    // iterate trhough the job data and extract relevant info
-    let jobStatus = "";
     let jobStartTime = "";
     let jobFinishTime = "";
-    // totalDevices mocked at 100 for progress bar
-    let finishedDevices = 0;
-    let totalDevices = 100;
-
-    let jobsData = this.state.jobsData;
-    jobsData.map((job, i) => {
-      jobStatus = job.status;
+    dryRunProgressData.map((job, i) => {
       jobStartTime = job.start_time;
       jobFinishTime = job.finish_time;
-
-      // generating random data to mock value in progress bar
-      finishedDevices = this.randomIntFromInterval(0, 100);
-      console.log("this is finsihedDevices", finishedDevices);
-      // extracting actual data when API populated
-      // let finishedDevices = job.finished_devices.length;
-      // let totalDevices = job.result._totals.selected_devices;
-      // let exceptionText = job.exception;
-
-      // stop the setInterval when job status is finished
-      if (jobStatus === "FINISHED" || jobStatus === "EXCEPTION") {
-        console.log("jobStatus is finished or errored");
-        clearInterval(this.state.repeatingData);
-      }
-      return jobStatus, jobStartTime, jobFinishTime, finishedDevices;
     });
+
+    //  totalDevices mocked at 100 for progress bar
+    let finishedDevices = 0;
+    let totalDevices = 100;
+    if (dryRunJobStatus === "RUNNING") {
+      dryRunProgressData.map((job, i) => {
+        finishedDevices = this.randomIntFromInterval(0, 100);
+        // finishedDevices = job.finished_devices;
+      });
+    }
+
+    let exceptionMessage = "";
+    let retryButtons = "";
+    if (dryRunJobStatus === "EXCEPTION") {
+      dryRunProgressData.map((job, i) => {
+        exceptionMessage = job.exception.message;
+      });
+
+      retryButtons = [
+        <div>
+          <button key="1" onClick={e => this.props.dryRunSyncStart(e)}>
+            Retry
+          </button>
+          <button
+            id="force-button"
+            key="2"
+            onClick={e => this.props.dryRunSyncStart(e)}
+          >
+            Force retry
+          </button>
+        </div>
+      ];
+    }
+
+    let failingDevices = "";
+    if (dryRunJobStatus === "FINISHED") {
+      finishedDevices = 100;
+      failingDevices = [<DeviceFailList devices={this.props.devices} />];
+    }
 
     return (
       <div className="workflow-container">

--- a/react-front/public/components/ConfigChange/DeviceFailList.js
+++ b/react-front/public/components/ConfigChange/DeviceFailList.js
@@ -4,26 +4,30 @@ class DeviceFailList extends React.Component {
   render() {
     let failedDeviceNameList = "";
     let devicesObj = this.props.devices;
-    // console.log("this is devicesObj", devicesObj);
     // split device object up into a key array and a values array
     const deviceNames = Object.keys(devicesObj);
     const deviceData = Object.values(devicesObj);
-    console.log("this deviceData", deviceData);
+    // console.log("this deviceData", deviceData);
 
+    // takes values array and creates a new object
+    // pairing failing device names with their position in the
     const failedDeviceNameObj = deviceData
+      // create a new array: add index values of devices with
+      // "falied: true" (otherwise add "false")
       .map((status, i) => {
         if (status.failed === true) {
           return i;
         }
         return false;
       })
+      // filter out non-index values
       .filter(status => status !== false)
+      // create a new object using the index array and the name array
       .reduce((obj, key) => {
         obj[key] = deviceNames[key];
         return obj;
       }, {});
-
-    console.log("failedDeviceNameObj: ", failedDeviceNameObj);
+    // console.log("failedDeviceNameObj: ", failedDeviceNameObj);
 
     return (
       <div>

--- a/react-front/public/components/ConfigChange/DeviceFailList.js
+++ b/react-front/public/components/ConfigChange/DeviceFailList.js
@@ -17,7 +17,11 @@ class DeviceFailList extends React.Component {
         }
         return false;
       })
-      .filter(status => status !== false);
+      .filter(status => status !== false)
+      .reduce((obj, key) => {
+        obj[key] = deviceNames[key];
+        return obj;
+      }, {});
 
     console.log("failedDeviceNameObj: ", failedDeviceNameObj);
 

--- a/react-front/public/components/ConfigChange/DeviceFailList.js
+++ b/react-front/public/components/ConfigChange/DeviceFailList.js
@@ -4,7 +4,21 @@ class DeviceFailList extends React.Component {
   render() {
     let failedDeviceNameList = "";
     let devicesObj = this.props.devices;
-    console.log("this is devicesObj", devicesObj);
+    // console.log("this is devicesObj", devicesObj);
+    // split device object up into a key array and a values array
+    const deviceNames = Object.keys(devicesObj);
+    const deviceData = Object.values(devicesObj);
+    console.log("this deviceData", deviceData);
+
+    const failedDeviceNameObj = deviceData
+      .map((status, i) => {
+        if (status.failed === true) {
+          return i;
+        }
+        return false;
+      });
+    
+      console.log("failedDeviceNameObj: ", failedDeviceNameObj);
 
     return (
       <div>

--- a/react-front/public/components/ConfigChange/DeviceFailList.js
+++ b/react-front/public/components/ConfigChange/DeviceFailList.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+class DeviceFailList extends React.Component {
+  render() {
+    let failedDeviceNameList = "";
+    let devicesObj = this.props.devices;
+    console.log("this is devicesObj", devicesObj);
+
+    return (
+      <div>
+        <ul>{failedDeviceNameList}</ul>
+      </div>
+    );
+  }
+}
+
+export default DeviceFailList;

--- a/react-front/public/components/ConfigChange/DeviceFailList.js
+++ b/react-front/public/components/ConfigChange/DeviceFailList.js
@@ -16,9 +16,10 @@ class DeviceFailList extends React.Component {
           return i;
         }
         return false;
-      });
-    
-      console.log("failedDeviceNameObj: ", failedDeviceNameObj);
+      })
+      .filter(status => status !== false);
+
+    console.log("failedDeviceNameObj: ", failedDeviceNameObj);
 
     return (
       <div>

--- a/react-front/public/components/ConfigChange/DeviceFailList.js
+++ b/react-front/public/components/ConfigChange/DeviceFailList.js
@@ -2,7 +2,6 @@ import React from "react";
 
 class DeviceFailList extends React.Component {
   render() {
-    let failedDeviceNameList = "";
     let devicesObj = this.props.devices;
     // split device object up into a key array and a values array
     const deviceNames = Object.keys(devicesObj);
@@ -28,6 +27,18 @@ class DeviceFailList extends React.Component {
         return obj;
       }, {});
     // console.log("failedDeviceNameObj: ", failedDeviceNameObj);
+
+    // pull out the names into an array and render
+    const failedDeviceNames = Object.values(failedDeviceNameObj);
+    let failedDeviceNameList = failedDeviceNames.map((name, i) => {
+      return (
+        <li key={i}>
+          <p className="error" key="0">
+            {name}
+          </p>
+        </li>
+      );
+    });
 
     return (
       <div>

--- a/react-front/public/components/ConfigChange/ProgressBar.js
+++ b/react-front/public/components/ConfigChange/ProgressBar.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-class ConfigChangeProgressBar extends React.Component {
+class ProgressBar extends React.Component {
   state = {};
   // this could propably be a function
   render() {
@@ -17,4 +17,4 @@ class ConfigChangeProgressBar extends React.Component {
   }
 }
 
-export default ConfigChangeProgressBar;
+export default ProgressBar;


### PR DESCRIPTION
**Background**: The names of individual devices that fail the dry run should be listed. DeviceFailList adds functionality that enables listing of only. 

<img width="500" alt="Screenshot 2019-12-09 at 09 14 45" src="https://user-images.githubusercontent.com/30963614/70418788-5f87ab80-1a64-11ea-9043-83f21f6a660f.png">

> This has been developed using jobID = this.state.dryRunSyncData.job_id);

**Summary**: 
- I have added functionality that: 
   - iterates through the values of the result blob and creates a new array of each index value of devices with "failed: true" (and "false" if "failed: false") 
   - filters out all "false", leaving only index values 
   - creates a new object pairing the index values with its device names
- I have created a final function that iterates through the device names and renders them in a list

**Next steps**:
- Render all other device info when a device name in the list is clicked
   - Add the relevant info to render 
   - Change render to include a clickable element and add animation as per DeviceList component 