### PR TITLE
Hook dry run button up with non-mock data

### DIFF
--- a/public/components/ConfigChange/ConfigChange.js
+++ b/public/components/ConfigChange/ConfigChange.js
@@ -19,15 +19,19 @@ class ConfigChange extends React.Component {
   };
 
   dryRunSyncStart = e => {
+    console.log("dry run will sync");
     const credentials = this.state.token;
-    let url = "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/device_syncto";
+    // let url = "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/device_syncto";
+    let url = "https://mdh.cnaas.sunet.se/api/v1.0/device_syncto";
     let dataToSend = { dry_run: true, all: true };
-    if (e.target.id === "force-button") {
-      dataToSend = { dry_run: true, all: true, force: true };
-    } else if (e.target.id === "confirm") {
-      console.log("you pressed confirm");
-      // dataToSend = { dry_run: false, all: true, force: true };
-    }
+    console.log("this is url", url);
+    // if (e.target.id === "force-button") {
+    //   dataToSend = { dry_run: true, all: true, force: true };
+    // } else if (e.target.id === "confirm") {
+    //   console.log("you pressed confirm");
+    // dataToSend = { dry_run: false, all: true, force: true };
+    // }
+    console.log("now it will post the data");
     postData(url, credentials, dataToSend).then(data => {
       console.log("this should be data", data);
       {
@@ -47,22 +51,12 @@ class ConfigChange extends React.Component {
   };
 
   pollJobStatus = () => {
-    // job id leading to finish / some devices failing / no diff
-    // use jobId from API in url
-    // let jobId = this.state.dryRunSyncData.job_id;
-    // let jobId = "16";
-    // job id leading to finish
-    // let jobId = "5ddbe1548b2d390c963b97d8";
-    // job id leading to finish / diff
-    let jobId = "5";
-    // let jobId = "5de8d5608b2d394fe74709a0";
-    // job id leading to exception
-    // let jobId = "12";
-    // let jobId = "5de8d5608b2d394fe74709b0"
+    let jobId = this.state.dryRunSyncData.job_id;
+    console.log("this is jobID:", jobId);
     const credentials = this.state.token;
-    let url = `https://tug-lab.cnaas.sunet.se:8443/api/v1.0/job/${jobId}`;
+    // let url = `https://tug-lab.cnaas.sunet.se:8443/api/v1.0/job/${jobId}`;
+    let url = `https://mdh.cnaas.sunet.se/api/v1.0/job/${jobId}`;
     this.repeatingJobData = setInterval(() => {
-      // console.log("start interval on:", jobId);
       getData(url, credentials).then(data => {
         console.log("this should be data.data.jobs", data.data.jobs);
         {

--- a/public/components/ConfigChange/ConfigChangeStep1.js
+++ b/public/components/ConfigChange/ConfigChangeStep1.js
@@ -12,9 +12,9 @@ class ConfigChangeStep1 extends React.Component {
 
   getCommitInfo = () => {
     const credentials = this.state.token;
-    let url =
-      "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/repository/settings";
-  
+    // let url =
+      // "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/repository/settings";
+    let url = "https://mdh.cnaas.sunet.se/api/v1.0/repository/settings"
     getData(url, credentials).then(data => {
       console.log("this should be data", data);
       {
@@ -33,8 +33,9 @@ class ConfigChangeStep1 extends React.Component {
   // this request takes some time, perhaps work in a "loading..."
   refreshCommitInfo = () => {
     const credentials = this.state.token;
-    let url =
-      "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/repository/settings";
+    // let url =
+    //   "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/repository/settings";
+    let url = "https://mdh.cnaas.sunet.se/api/v1.0/repository/settings";
     let dataToSend = { action: "REFRESH" };
 
     putData(url, credentials, dataToSend).then(data => {

--- a/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/public/components/ConfigChange/ConfigChangeStep2.js
@@ -18,7 +18,7 @@ class ConfigChangeStep2 extends React.Component {
     console.log("this is props in configchange step 2", this.props);
     let dryRunProgressData = this.props.dryRunProgressData;
     let dryRunJobStatus = this.props.dryRunJobStatus;
-
+    console.log("this is dryRunProgressData", dryRunProgressData);
     let jobStartTime = "";
     let jobFinishTime = "";
     dryRunProgressData.map((job, i) => {
@@ -66,7 +66,7 @@ class ConfigChangeStep2 extends React.Component {
     }
 
     // stop the setInterval when job status is finished
-    if (dryRunJobStatus === "FINISHED" || dryRunJobStatus  === "EXCEPTION") {
+    if (dryRunJobStatus === "FINISHED" || dryRunJobStatus === "EXCEPTION") {
       console.log("jobStatus is finished or errored");
       clearInterval(this.state.repeatingData);
     }

--- a/public/components/ConfigChange/ConfigChangeStep2.js
+++ b/public/components/ConfigChange/ConfigChangeStep2.js
@@ -73,6 +73,7 @@ class ConfigChangeStep2 extends React.Component {
     // allow a force retry of dry run if it errored
     // jobStatus === "EXCEPTION"
     if (dryRunJobStatus === "EXCEPTION") {
+      let error = "";
       console.log("jobStatus errored");
       error = [
         <div>

--- a/public/components/DeviceList.js
+++ b/public/components/DeviceList.js
@@ -114,7 +114,7 @@ class DeviceList extends React.Component {
         filterValue;
     }
     fetch(
-      "https://tug-lab.cnaas.sunet.se:8443/api/v1.0/devices?sort=" +
+      "https://mdh.cnaas.sunet.se/api/v1.0/devices?sort=" +
         sortField +
         filterParams +
         "&page=" +


### PR DESCRIPTION
**Background**: To make the site process real data the requests are updated to request more realistic data (non-mock)

**Summary**: 
- Comments out existing URLs and adds the non-mock data URL
- Fixes issue with the error variable not being defined  

**Next step**: Populating the progress bar with non-mock data at dry run