### PR TITLE
Configchange button status improvements

### DIFF
--- a/public/components/ConfigChange/ConfigChange.js
+++ b/public/components/ConfigChange/ConfigChange.js
@@ -14,23 +14,38 @@ const io = require("socket.io-client");
 var socket = null;
 
 class ConfigChange extends React.Component {
-  state = {
-    dryRunSyncData: [],
-    dryRunSyncJobid: null,
-    dryRunProgressData: [],
-    dryRunResultData: [],
-    dryRunTotalCount: 0,
-    synctoForce: false,
-    liveRunSyncData: [],
-    liveRunSyncJobid: null,
-    liveRunProgressData: [],
-    liveRunResultData: [],
-    liveRunTotalCount: 0,
-    job_comment: "",
-    job_ticket_ref: "",
-    logLines: [],
-    blockNavigation: false
+  getInitialState() {
+    return {
+      dryRunSyncData: [],
+      dryRunSyncJobid: null,
+      dryRunProgressData: [],
+      dryRunTotalCount: 0,
+      synctoForce: false,
+      liveRunSyncData: [],
+      liveRunSyncJobid: null,
+      liveRunProgressData: [],
+      liveRunTotalCount: 0,
+      job_comment: "",
+      job_ticket_ref: "",
+      logLines: [],
+      blockNavigation: false,
+      repoWorking: false
+    }
   };
+
+  constructor() {
+    super();
+    this.state = this.getInitialState();
+  }
+
+  resetState = () => {
+    console.log(this.getInitialState());
+    this.setState(this.getInitialState());
+  }
+
+  setRepoWorking = (working_status) => {
+    this.setState({repoWorking: working_status});
+  }
 
   updateComment(e) {
     const val = e.target.value;
@@ -230,6 +245,11 @@ class ConfigChange extends React.Component {
       }
       newLogLines.push(data + "\n");
       this.setState({logLines: newLogLines});
+      // Disable confirm commit by reseting dryrun jobstatus if someone else refreshes repos
+      if (data.includes("refresh repo") === true) {
+        this.setState({dryRunProgressData: []});
+        console.log("Refresh repo event, reset dryrun status: ", data);
+      }
     });
   };
 
@@ -305,6 +325,7 @@ class ConfigChange extends React.Component {
           />
           <ConfigChangeStep1
             dryRunJobStatus={dryRunJobStatus}
+            setRepoWorking={this.setRepoWorking}
           />
           <DryRun
             dryRunSyncStart={this.deviceSyncStart}
@@ -314,6 +335,8 @@ class ConfigChange extends React.Component {
             devices={dryRunResults}
             totalCount={this.state.dryRunTotalCount}
             logLines={this.state.logLines}
+            resetState={this.resetState}
+            repoWorkingState={this.state.repoWorking}
           />
           <VerifyDiff
             dryRunChangeScore={dryRunChangeScore}

--- a/public/components/ConfigChange/ConfigChangeStep1.js
+++ b/public/components/ConfigChange/ConfigChangeStep1.js
@@ -6,7 +6,10 @@ import { Popup } from "semantic-ui-react";
 class ConfigChangeStep1 extends React.Component {
   state = {
     commitInfo: {},
-    commitUpdateInfo: {}
+    commitUpdateInfo: {
+      'settings': null,
+      'templates': null,
+    }
   };
 
   getRepoStatus = (repo_name) => {
@@ -31,21 +34,22 @@ class ConfigChangeStep1 extends React.Component {
 
   // this request takes some time, perhaps work in a "loading..."
   refreshRepo = (repo_name) => {
-    let resetCommitUpdateInfo = this.state.commitUpdateInfo;
-    resetCommitUpdateInfo[repo_name] = "";
-    this.setState({commitUpdateInfo: resetCommitUpdateInfo});
+    let newCommitUpdateInfo = this.state.commitUpdateInfo;
+    newCommitUpdateInfo[repo_name] = "updating...";
+    this.setState({commitUpdateInfo: newCommitUpdateInfo});
+    this.props.setRepoWorking(true);
 
     const credentials = localStorage.getItem("token");
     let url = process.env.API_URL + "/api/v1.0/repository/" + repo_name;
     let dataToSend = { action: "REFRESH" };
     let newCommitInfo = this.state.commitInfo;
-    let newCommitUpdateInfo = this.state.commitUpdateInfo;
 
     putData(url, credentials, dataToSend).then(data => {
       // console.log("this should be data", data);
       if ( data.status === "success" ) {
         newCommitUpdateInfo[repo_name] = "success";
         newCommitInfo[repo_name] = data.data;
+        this.props.setRepoWorking(false);
       } else {
         newCommitUpdateInfo[repo_name] = "error";
         newCommitInfo[repo_name] = data.message;
@@ -103,14 +107,14 @@ class ConfigChangeStep1 extends React.Component {
     let buttonsDisabled = false;
     if (this.props.dryRunJobStatus) {
       buttonsDisabled = true;
+    } else if (this.state.commitUpdateInfo['settings'] == 'updating...' || 
+            this.state.commitUpdateInfo['templates'] == 'updating...') {
+      buttonsDisabled = true;
     }
     return (
       <div className="task-container">
         <div className="heading">
           <h2>Refresh repositories (1/4)</h2>
-          <a href="#">
-            <button className="close">Close</button>
-          </a>
         </div>
         <div className="task-collapsable">
           <div className="info">

--- a/public/components/ConfigChange/ConfigChangeStep4.js
+++ b/public/components/ConfigChange/ConfigChangeStep4.js
@@ -43,6 +43,7 @@ class ConfigChangeStep4 extends React.Component {
       if (!this.props.jobTicketRef || !this.props.jobComment) {
         warnings.push(
           <Popup
+            key="popup1"
             content="Ticket reference or comment is missing"
             position="top center"
             hoverable
@@ -54,6 +55,7 @@ class ConfigChangeStep4 extends React.Component {
       if (this.props.dryRunChangeScore && this.props.dryRunChangeScore > warnChangeScore) {
         warnings.push(
           <Popup
+            key="popup2"
             content={"High change score: "+this.props.dryRunChangeScore}
             position="top center"
             hoverable
@@ -64,6 +66,7 @@ class ConfigChangeStep4 extends React.Component {
       if (this.props.synctoForce) {
         warnings.push(
           <Popup
+            key="popup3"
             content={"Local changes will be overwritten!"}
             position="top center"
             hoverable
@@ -74,6 +77,7 @@ class ConfigChangeStep4 extends React.Component {
       if (warnings.length == 0) {
         warnings.push(
           <Popup
+            key="popup4"
             content={"No warnings"}
             position="top center"
             hoverable
@@ -87,9 +91,6 @@ class ConfigChangeStep4 extends React.Component {
       <div className="task-container">
         <div className="heading">
           <h2>Commit configuration (4/4)</h2>
-          <a href="#">
-            <button className="close">Close</button>
-          </a>
         </div>
         <div className="task-collapsable">
           <p>Step 4 of 4: Final step</p>

--- a/public/components/ConfigChange/DryRun/DryRun.js
+++ b/public/components/ConfigChange/DryRun/DryRun.js
@@ -6,7 +6,8 @@ import { Form, Checkbox } from "semantic-ui-react";
 
 class DryRun extends React.Component {
   state = {
-    "resync": false
+    "resync": false,
+    "dryrunButtonDisabled": false
   };
 
   checkboxChangeHandler = (event, data) => {
@@ -15,17 +16,23 @@ class DryRun extends React.Component {
     });
   };
 
-  dryrunButtonOnclick = (e) => {
+  dryrunButtonOnclick() {
     this.props.dryRunSyncStart({"resync": this.state.resync});
-    var confirmButtonElem = document.getElementById("dryrunButton");
-    confirmButtonElem.disabled = true;
+    this.setState({"dryrunButtonDisabled": true});
   };
+
+  resetButtonOnclick() {
+    this.props.resetState();
+    this.setState({"dryrunButtonDisabled": false});
+  }
 
   render() {
     let dryRunProgressData = this.props.dryRunProgressData;
     let dryRunJobStatus = this.props.dryRunJobStatus;
     let jobId = this.props.jobId;
     let error = "";
+    let dryrunButtonDisabled = this.state.dryrunButtonDisabled;
+    let resetButtonDisabled = true;
 
     if (dryRunJobStatus === "EXCEPTION") {
       // console.log("jobStatus errored");
@@ -38,14 +45,17 @@ class DryRun extends React.Component {
         />
       ];
     }
+    if (dryRunJobStatus === "FINISHED") {
+      resetButtonDisabled = false;
+    }
+    if (this.props.repoWorkingState === true) {
+      dryrunButtonDisabled = true;
+    }
 
     return (
       <div className="task-container">
         <div className="heading">
           <h2>Dry run (2/4)</h2>
-          <a href="#">
-            <button className="close">Close</button>
-          </a>
         </div>
         <div className="task-collapsable">
           <p>
@@ -57,8 +67,11 @@ class DryRun extends React.Component {
               <Checkbox label="Re-sync devices (check for local changes made outside of NMS)" name="resync" checked={this.state.resync} onChange={this.checkboxChangeHandler} /> 
             </div>
             <div className="info">
-              <button id="dryrunButton" onClick={e => this.dryrunButtonOnclick(e)}>
+              <button id="dryrunButton" disabled={dryrunButtonDisabled} onClick={() => this.dryrunButtonOnclick()}>
                 Start config dry run
+              </button>
+              <button id="resetButton" disabled={resetButtonDisabled} onClick={() => this.resetButtonOnclick()}>
+                Start over
               </button>
             </div>
           </Form>

--- a/public/components/ConfigChange/VerifyDiff/VerifyDiff.js
+++ b/public/components/ConfigChange/VerifyDiff/VerifyDiff.js
@@ -13,9 +13,6 @@ class VerifyDiff extends React.Component {
       <div className="task-container">
         <div className="heading">
           <h2>Verify difference (3/4)</h2>
-          <a href="#">
-            <button className="close">Close</button>
-          </a>
         </div>
         <div className="task-collapsable">
           <p>Step 3 of 4: Look through and verify diff</p>

--- a/public/components/Dashboard.js
+++ b/public/components/Dashboard.js
@@ -1,12 +1,13 @@
 import React from "react";
-import { Container, Grid } from "semantic-ui-react";
+import { Container, Grid, Popup } from "semantic-ui-react";
 import checkResponseStatus from "../utils/checkResponseStatus";
 import getData from "../utils/getData";
 
 class Dashboard extends React.Component {
   state = {
     commitInfo: {},
-    deviceCount: {}
+    deviceCount: {},
+    systemVersion: {}
   };
 
   componentDidMount() {
@@ -14,6 +15,7 @@ class Dashboard extends React.Component {
     this.getRepoStatus('templates');
     this.getDeviceCount("managed", "filter[state]=MANAGED");
     this.getDeviceCount("unsynchronized", "filter[state]=MANAGED&filter[synchronized]=false");
+    this.getSystemVersion();
   }
 
   getRepoStatus = (repo_name) => {
@@ -61,6 +63,26 @@ class Dashboard extends React.Component {
     } )
   }
 
+  getSystemVersion = () => {
+    const credentials = localStorage.getItem("token");
+    let url = process.env.API_URL + "/api/v1.0/system/version";
+    let newSystemVersion = this.state.systemVersion;
+    getData(url, credentials).then(data => {
+      // console.log("this should be data", data);
+      newSystemVersion = data.data;
+      {
+        this.setState(
+          {
+            systemVersion: newSystemVersion
+          },
+          () => {
+            console.log("system version", this.state.systemVersion);
+          }
+        );
+      }
+    });
+  };
+
   headerCount = response => {
     const totalCountHeader = response.headers.get("X-Total-Count");
     if (totalCountHeader !== null && !isNaN(totalCountHeader)) {
@@ -96,6 +118,16 @@ class Dashboard extends React.Component {
             <Grid.Column width={8}>
               <p>Managed devices: <a href={"/devices?filterstring=filter%5Bstate%5D%3DMANAGED"}>{this.state.deviceCount["managed"]}</a></p>
               <p>Unsynchronized devices: <a href={"/devices?filterstring=filter%5Bsynchronized%5D%3Dfalse"}>{this.state.deviceCount["unsynchronized"]}</a></p>
+            </Grid.Column>
+            <Grid.Column width={8}>
+              <p>
+                <Popup
+                  content={"Detailed git commit version: " + this.state.systemVersion['git_version']}
+                  position="top left"
+                  hoverable
+                  trigger={<a href="https://github.com/SUNET/cnaas-nms/releases" alt="CNaaS-NMS github page" target="_blank">CNaaS-NMS version: {this.state.systemVersion['version']}</a>}
+                />
+              </p>
             </Grid.Column>
           </Grid>
         </Container>

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -141,6 +141,10 @@ footer {
   background-color: #f4f4f4;
 }
 
+.task-container .heading h2 {
+  margin: 32px 0 32px 0;
+}
+
 .task-container .close {
   background: transparent;
   border: none;
@@ -162,6 +166,10 @@ footer {
 .task-collapsable .info {
   display: flex;
   align-items: baseline;
+}
+
+.ui.checkbox {
+  margin: 16px;
 }
 
 a.active {

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -46,9 +46,17 @@ nav li {
 }
 
 a {
-  text-transform: Captalize;
   color: #003049;
+  text-decoration: underline;
+}
+
+nav a {
   text-decoration: none;
+}
+
+nav a.active {
+  color: #ff4500;
+  text-decoration: underline;
 }
 
 h1,
@@ -172,10 +180,6 @@ footer {
   margin: 16px;
 }
 
-a.active {
-  color: #ff4500;
-  text-decoration: underline;
-}
 
 table,
 thead,


### PR DESCRIPTION
Add 'start over' button at dryrun step. Show working status of refreh repo. Add more checks to disable dryrun while settings is refreshed. Disable commit liverun if someone else did refresh repo.