### PR TITLE
Make traceback hidden, only show last line

### DIFF
--- a/public/components/ConfigChange/VerifyDiff/VerifyDiffResult.js
+++ b/public/components/ConfigChange/VerifyDiff/VerifyDiffResult.js
@@ -66,8 +66,11 @@ class VerifyDiffResult extends React.Component {
               <p className="device-name" key={i}>
                 {nameAndExceptionArray[0]} failed result
               </p>
-              <pre>
+              <pre className="traceback">
                 {nameAndExceptionArray[1]}
+              </pre>
+              <pre className="exception">
+                {nameAndExceptionArray[1].split("\n").slice(-2).join("\n")}
               </pre>
             </li>
           );

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -310,7 +310,6 @@ progress::-moz-progress-bar {
 /* diff box styles */
 #diff-box {
   background-color: #ececec;
-  color: #ff4500;
   margin: 0 1rem;
 }
 
@@ -328,8 +327,21 @@ progress::-moz-progress-bar {
   margin: 0;
 }
 
-#diff-box pre {
+#diff-box pre{
   padding-left: 1rem;
+}
+
+#diff-box pre.exception {
+  white-space: pre-wrap;
+  color: #ff4500;
+}
+
+#diff-box pre.traceback {
+  white-space: pre-wrap;
+  color: #000;
+  height: 1em;
+  overflow-y: scroll;
+  font-size: 80%;
 }
 
 /* log output styles */


### PR DESCRIPTION
Make last line of traceback visible and hide main content of traceback for users so it's easy to focus on the relevant bit