### PR TITLE
add fallback use of default token for netbox if user has not configured

### DIFF
--- a/docker/front/config/nginx_app.conf
+++ b/docker/front/config/nginx_app.conf
@@ -1,3 +1,4 @@
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=auth_cache:1m max_size=64m inactive=60m;
 server {
     listen 4443 ssl;
     server_name cnaas-front;
@@ -31,6 +32,24 @@ server {
         proxy_pass CNAAS_AUTH_URL;
         proxy_set_header Host            $host;
         proxy_set_header X-Forwarded-For $remote_addr;
+    }
+
+    location /api/v1.0/netboxauth {
+        proxy_pass https://api:1443/api/v1.0/devices?per_page=1;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_cache auth_cache;
+        proxy_cache_key "$http_authorization$remote_addr";
+        proxy_cache_valid 200 300s;
+        proxy_cache_valid any 10s;
+    }
+
+    location /netbox/ {
+        auth_request /api/v1.0/netboxauth;
+        proxy_pass NETBOX_API_URL;
+        proxy_set_header Authorization "Token NETBOX_AUTH_TOKEN";
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_ssl_server_name on;
     }
 
     location / {

--- a/docker/front/start-nginx.sh
+++ b/docker/front/start-nginx.sh
@@ -5,6 +5,8 @@ export CNAAS_HTTPD_URL=`echo $CNAAS_API_URL | sed 's/https/http/g'`
 sed -e "s|^\(.*proxy_pass \)CNAAS_API_URL;$|\1$CNAAS_API_URL;|" \
     -e "s|^\(.*proxy_pass \)CNAAS_AUTH_URL;$|\1$CNAAS_AUTH_URL;|" \
     -e "s|^\(.*proxy_pass \)CNAAS_HTTPD_URL;$|\1$CNAAS_HTTPD_URL;|" \
+    -e "s|^\(.*proxy_pass \)NETBOX_API_URL;$|\1$NETBOX_API_URL;|" \
+    -e "s|^\(.*proxy_set_header Authorization \"Token \)NETBOX_API_TOKEN\";$|\1$NETBOX_API_TOKEN\";|" \
   < /etc/nginx/sites-available/nginx_app.conf > /tmp/nginx_app.conf.new \
   && cat /tmp/nginx_app.conf.new > /etc/nginx/sites-available/nginx_app.conf
 

--- a/public/components/DeviceList/DeviceList.js
+++ b/public/components/DeviceList/DeviceList.js
@@ -492,17 +492,24 @@ class DeviceList extends React.Component {
 
   getNetboxModelData(hostname) {
     const model = this.getModel(hostname);
-    const credentials = localStorage.getItem("netboxToken");
-    if (!credentials || !process.env.NETBOX_API_URL) {
+    if (!process.env.NETBOX_API_URL) {
       return null;
+    }
+    let credentials = localStorage.getItem("netboxToken");
+    let getFunc = getDataToken;
+    let url = process.env.NETBOX_API_URL;
+    if (!credentials) {
+      credentials = localStorage.getItem("token");
+      getFunc = getData;
+      url = `${process.env.API_URL}/netbox`;
     }
 
     // if this.state.netboxModelData map does not have an object for model, fetch data from netbox
     const mod = this.state.netboxModelData[model];
     if (mod) return mod;
 
-    getDataToken(
-      `${process.env.NETBOX_API_URL}/api/dcim/device-types/?part_number__ie=${model}`,
+    getFunc(
+      `${url}/api/dcim/device-types/?part_number__ie=${model}`,
       credentials,
     ).then((data) => {
       if (data.count === 1) {
@@ -519,17 +526,20 @@ class DeviceList extends React.Component {
   }
 
   getNetboxDeviceData(hostname) {
-    const credentials = localStorage.getItem("netboxToken");
-    if (
-      !credentials ||
-      !process.env.NETBOX_API_URL ||
-      !process.env.NETBOX_TENANT_ID
-    ) {
+    if (!process.env.NETBOX_API_URL || !process.env.NETBOX_TENANT_ID) {
       return null;
     }
+    let credentials = localStorage.getItem("netboxToken");
+    let getFunc = getDataToken;
+    let url = process.env.NETBOX_API_URL;
+    if (!credentials) {
+      credentials = localStorage.getItem("token");
+      getFunc = getData;
+      url = `${process.env.API_URL}/netbox`;
+    }
 
-    getDataToken(
-      `${process.env.NETBOX_API_URL}/api/dcim/devices/?name__ie=${hostname}&tenant_id=${process.env.NETBOX_TENANT_ID}`,
+    getFunc(
+      `${url}/api/dcim/devices/?name__ie=${hostname}&tenant_id=${process.env.NETBOX_TENANT_ID}`,
       credentials,
     ).then((data) => {
       if (data.count === 1) {


### PR DESCRIPTION
a user-specific token in browser
nginx does auth via auth_request to /devices , if user can access that with their jwt token we allow using the default token configured from env var when proxying requests to ipam