### PR TITLE
Added ref checks to short-circuit logic that trigger getDevices

### DIFF
--- a/src/components/DeviceList/DeviceList.js
+++ b/src/components/DeviceList/DeviceList.js
@@ -180,7 +180,7 @@ function DeviceTableHeaderFilter({ column, filterData, handleFilterChange }) {
     // Set new debounce
     debounceTimeout.current = setTimeout(() => {
       handleFilterChange(column, value); // triggers fetch
-    }, 300);
+    }, 250);
   };
 
   const synchronizedOptions = [
@@ -673,21 +673,13 @@ function DeviceList() {
   // https://reactrouter.com/api/hooks/useSearchParams
   const searchParams = useQuery();
 
-  const skipNextFilterSync = useRef(false); // skip setting filterData
-  const skipNextUrlSync = useRef(false); // skip pushing to URL
-
   useEffect(() => {
-    if (skipNextFilterSync.current) {
-      skipNextFilterSync.current = false;
-      return; // skip because it came from filterData update
-    }
     // Set filterData on searchParam change
     const locationFilterData = {};
     for (const [key, value] of searchParams.entries()) {
       const match = key.match(/^filter\[(.+)\]$/);
       if (match) locationFilterData[match[1]] = value;
     }
-    skipNextUrlSync.current = true;
 
     setFilterData(locationFilterData);
   }, [searchParams]);
@@ -764,7 +756,7 @@ function DeviceList() {
   // Update deviceData on changes
   useEffect(() => {
     getDevices();
-  }, [sortColumn, sortDirection, filterData, activePage, resultsPerPage]);
+  }, [sortColumn, sortDirection, searchParams, activePage, resultsPerPage]);
 
   // Set localStorage on changes
   useEffect(() => {
@@ -780,10 +772,6 @@ function DeviceList() {
 
   // Set queryParams on filterData changes
   useEffect(() => {
-    if (skipNextUrlSync.current) {
-      skipNextUrlSync.current = false;
-      return; // skip because it came from searchParams update
-    }
     const filterParams = Object.fromEntries(
       Object.entries(filterData)
         .filter(([, value]) => value) // skip empty values
@@ -795,7 +783,6 @@ function DeviceList() {
 
     // Only push if it have changed
     // Do not push nothing
-    skipNextFilterSync.current = true;
     if (newSearch && newSearch !== location.search) {
       history.push(newSearch);
     } else if (!newSearch && location.search) {
@@ -819,11 +806,13 @@ function DeviceList() {
       urlParams.sort = `${prefix}${sortColumn}`;
     }
 
-    for (const [key, value] of Object.entries(filterData)) {
+    for (const [key, value] of searchParams.entries()) {
       if (!value) continue; // skip empty values
-
-      const operator = operatorMap[key] ?? "[contains]";
-      urlParams[`filter[${key}]${operator}`] = value;
+      const match = key.match(/^filter\[(.+)\]$/);
+      if (!match) continue;
+      const matchedKey = match[1];
+      const operator = operatorMap[matchedKey] ?? "[contains]";
+      urlParams[`filter[${matchedKey}]${operator}`] = value;
     }
 
     const filterString = new URLSearchParams(urlParams).toString();


### PR DESCRIPTION
When I added the feature saving filterData state in queryparams I inadvertently introduced a bug where changing filterState triggered getDevices twice instead of only one.
The easiest way was to add two refs that keep track of this and short circuits some useEffects that trigger each other.
The issue is when navigating with back and forward it triggers only searchParams so filterData must change when that happens.