### PR TITLE
Reset to page 1 during filtering

### DIFF
--- a/src/components/DeviceList/DeviceList.js
+++ b/src/components/DeviceList/DeviceList.js
@@ -788,6 +788,8 @@ function DeviceList() {
     } else if (!newSearch && location.search) {
       history.push("/devices");
     }
+    // Reset to page 1 during filtering
+    setActivePage(1);
   }, [filterData]);
 
   const getDevices = async () => {


### PR DESCRIPTION
Reset to page 1 during filtering to mitigate trying to get a page that does not exist.