### PR TITLE
batch multiple events into one toast, because generating 50+ toasts

### DIFF
--- a/src/components/ConfigChange/ConfigChange.js
+++ b/src/components/ConfigChange/ConfigChange.js
@@ -23,7 +23,7 @@ const STATUS_STOPPED = ["FINISHED", "EXCEPTION", "ABORTED"];
 const STATUS_RUNNING = ["RUNNING"];
 
 // Batch sync toast notifications
-let pendingHostnames = new Set();
+const pendingHostnames = new Set();
 let toastBatchTimer = null;
 const BATCH_INTERVAL_MS = 1000;
 


### PR DESCRIPTION
(even if only 3 is displayed) might cause maximumDepthExceeded in react